### PR TITLE
Basic logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Epsilon-Telemetry-Server
+

--- a/.netrc
+++ b/.netrc
@@ -1,0 +1,3 @@
+machine github.com
+login   bseto
+password d5138261b3eae044dc84b12ad6998eb9be73f1ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: go
 
+
+install:
+    - go get github.com/fatih/color
+go:
+    - 1.7.x
+
+script:
+    - go test -v ./...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: go
 
 
 install:
-    - go get github.com/fatih/color
+    - go get -v
 go:
     - 1.7.x
 
 script:
     - go test -v ./...
 
+before_install:
+    - chmod 600 .netrc
+    - cp .netrc ~

--- a/logger/log.go
+++ b/logger/log.go
@@ -35,20 +35,24 @@ func GetLogger() *logger {
 //Look for the caller of the Logf function and automatically
 //print in the following format:
 //<timestamp><caller><Message>
-func (l *logger) Logf(format string, args ...interface{}) {
+func (l *logger) Logf(format string, args ...interface{}) string {
 	//TODO Maybe accept logging levels/importance of the message
 	t := time.Now()
 	timeStamp := t.Format("2006-01-02 15:04:05.000")
-	caller := findCaller()
+	caller := findCaller(3)
 	l.c["cyan"].PrintfFunc()("%s ", timeStamp)
 	l.c["yellow"].PrintfFunc()("%s: ", caller)
-	fmt.Printf(format, args...)
+	logString := fmt.Sprintf(format, args...)
+	fmt.Print(logString)
+	return logString
 }
 
-//A function that that looks at the callstack for the caller 2 above it
-func findCaller() string {
+//1 = itself
+//2 = 1 above (this would be Logf)
+//3 = 2 above etc.
+func findCaller(callstack int) string {
 	functionPointer := make([]uintptr, 1)
-	n := runtime.Callers(3, functionPointer)
+	n := runtime.Callers(callstack, functionPointer)
 	if n == 0 {
 		return "unknown function"
 	}

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+//Stores the colors once
+type logger struct {
+	c map[string]*color.Color
+}
+
+var instance *logger
+
+//Creates the Singleton Logger
+func InitLogger() {
+	//TODO Needs to accept a path to output the log to.
+	//TODO Maybe accept a logging level on what to display. That way, someone
+	//can run this on DEBUG mode and have all the DEBUG messages print out.
+	instance = &logger{}
+	instance.c = make(map[string]*color.Color)
+	instance.c["cyan"] = color.New(color.FgCyan)
+	instance.c["yellow"] = color.New(color.FgHiYellow)
+}
+
+//Returns an instance to the logger
+func GetLogger() *logger {
+	return instance
+}
+
+//A wrapper function for fmt.Printf. This function will
+//Look for the caller of the Logf function and automatically
+//print in the following format:
+//<timestamp><caller><Message>
+func (l *logger) Logf(format string, args ...interface{}) {
+	//TODO Maybe accept logging levels/importance of the message
+	t := time.Now()
+	timeStamp := t.Format("2006-01-02 15:04:05.000")
+	caller := findCaller()
+	l.c["cyan"].PrintfFunc()("%s ", timeStamp)
+	l.c["yellow"].PrintfFunc()("%s: ", caller)
+	fmt.Printf(format, args...)
+}
+
+//A function that that looks at the callstack for the caller 2 above it
+func findCaller() string {
+	functionPointer := make([]uintptr, 1)
+	n := runtime.Callers(3, functionPointer)
+	if n == 0 {
+		return "unknown function"
+	}
+
+	function := runtime.FuncForPC(functionPointer[0] - 1)
+	if function == nil {
+		return "unknown function"
+	}
+	return function.Name()
+}

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,0 +1,14 @@
+package logger
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindCaller(t *testing.T) {
+	testCaller := "github.com/Epsilon-Telemetry-Server/logger.TestFindCaller"
+	caller := findCaller(2)
+	if strings.Compare(caller, testCaller) != 0 {
+		t.Errorf("findCaller should have returned\nThis:\t\t%s\nInstead: \t%s", testCaller, caller)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/Epsilon-Telemetry-Server/logger"
+	"github.com/Epsilon-Telemetry-Server/presenter"
+)
+
+func main() {
+	http.HandleFunc("/api", presenter.ApiPresenter)
+
+	logger.InitLogger()
+	log := logger.GetLogger()
+	log.Logf("The server is served on port %s\n", ":8080")
+
+	//must be at the bottom
+	http.ListenAndServe(":8080", nil)
+}

--- a/presenter/api.go
+++ b/presenter/api.go
@@ -1,0 +1,15 @@
+package presenter
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Epsilon-Telemetry-Server/logger"
+)
+
+func ApiPresenter(w http.ResponseWriter, r *http.Request) {
+	logger.InitLogger()
+	log := logger.GetLogger()
+	log.Logf("a GET was received on the APIPresenter\n")
+	fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
+}


### PR DESCRIPTION
The basic logger is a wrapper to the fmt.Printf function.
It is created in main.go, and will exist as a global singleton.
Call logger.GetLogger() to grab an instance of the singleton.

The main purpose of the logger is to automatically prepend timestamps,
and the calling functions name onto the original message string.