### PR TITLE
Change resizing of progress spinners so they stay within the card.

### DIFF
--- a/web-app/src/app/rightpanel/rightpanel.component.css
+++ b/web-app/src/app/rightpanel/rightpanel.component.css
@@ -9,6 +9,8 @@
 .car-misc,
 .battery-misc {
   width: 40%;
+  min-width:120px;
+  font-size: 12px;
   display: flex;
   justify-content: space-between;
   flex-direction: column;
@@ -134,7 +136,7 @@ mat-divider {
 }
 
 .velocity-number {
-  font-size: 25px;
+  font-size: 18px;
 }
 
 #set-velocity {
@@ -172,7 +174,7 @@ mat-divider {
   }
 
   .velocity-number {
-    font-size: 18px;
+    font-size: 24px;
   }
 
   .velocity-data p,

--- a/web-app/src/app/rightpanel/rightpanel.component.css
+++ b/web-app/src/app/rightpanel/rightpanel.component.css
@@ -49,8 +49,27 @@
 
 .spinners {
   align-self: center;
-  width: 180px;
-  height: 180px;
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+}
+
+.mat-progress-spinner {
+  position:  absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+
+  align-self: center;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.mat-progress-spinner ::ng-deep svg {
+  align-self: center;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 #overlay-0 {
@@ -102,6 +121,11 @@ mat-divider {
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  position:  absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .velocity-data p,
@@ -145,21 +169,6 @@ mat-divider {
   .battery-misc {
     padding: 12px;
     font-size: 14px;
-  }
-
-  .spinners {
-    width: 140px;
-    height: 140px;
-  }
-
-  .mat-progress-spinner {
-    width: 140px !important;
-    height: 140px !important;
-  }
-
-  .mat-progress-spinner ::ng-deep svg {
-    width: 140px !important;
-    height: 140px !important;
   }
 
   .velocity-number {


### PR DESCRIPTION
Previously, the progress circles would size out of the card if the
screen size was too small. Changed the width & height of the
spinner container so that it stays in the card, and made the mat-
spinners themselves take up the space.

Fixes: #39 

Reference:
http://www.mademyday.de/css-height-equals-width-with-pure-css.html