### PR TITLE
Address floating point issues

### DIFF
--- a/web-app/src/app/_services/battery.service.ts
+++ b/web-app/src/app/_services/battery.service.ts
@@ -3,6 +3,7 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { Battery } from '../_objects/battery';
 import { ITelemetryData } from '../_objects/interfaces/telemetry-data.interface';
 import { WebSocketService } from '../websocket.service';
+import { RoundingService } from './rounding.service';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +14,7 @@ export class BatteryService {
 
   private battery: Battery;
 
-  constructor(private wsService: WebSocketService) {
+  constructor(private wsService: WebSocketService, private rService: RoundingService) {
     this.battery$ = new EventEmitter<Battery>();
     this.battery = new Battery;
 
@@ -42,7 +43,7 @@ export class BatteryService {
     this.battery.bmsRelayStatusFlags.malfunctionIndicatorActive = data.malfunctionindicatoractive;
     this.battery.bmsRelayStatusFlags.multiPurposeInputSignalStatus = data.multipurposeinputsignalstatus;
     this.battery.fanSpeed = data.fanspeed;
-    this.battery.fanVoltage = data.fanvoltage;
+    this.battery.fanVoltage = this.rService.getRoundedValue(data.fanvoltage, 2);
     this.battery.highCellVoltage = data.highcellvoltage;
     this.battery.highCellVoltageId = data.highcellvoltageid;
     this.battery.highTemperature = data.hightemperature;
@@ -52,14 +53,14 @@ export class BatteryService {
     this.battery.lowCellVoltageId = data.lowcellvoltageid;
     this.battery.lowTemperature = data.lowtemperature;
     this.battery.lowThermistorId = data.lowthermistorid;
-    this.battery.packAmphours = data.packamphours;
-    this.battery.packCurrent = data.packcurrent;
-    this.battery.packDepthOfDischarge = data.packdepthofdischarge;
-    this.battery.packStateOfCharge = data.packstateofcharge;
-    this.battery.packVoltage = data.packvoltage;
+    this.battery.packAmphours = this.rService.getRoundedValue(data.packamphours, 2);
+    this.battery.packCurrent = this.rService.getRoundedValue(data.packcurrent, 2);
+    this.battery.packDepthOfDischarge = this.rService.getRoundedValue(data.packdepthofdischarge, 2);
+    this.battery.packStateOfCharge = this.rService.getRoundedValue(data.packstateofcharge, 2);
+    this.battery.packVoltage = this.rService.getRoundedValue(data.packvoltage, 2);
     this.battery.populatedCells = data.populatedcells;
     this.battery.requestedFanSpeed = data.requestedfanspeed;
     this.battery.totalPackCapacity = 168;
-    this.battery.twelvevinputVoltage = data.twelvevinputvoltage;
+    this.battery.twelvevinputVoltage = this.rService.getRoundedValue(data.twelvevinputvoltage, 2);
   }
 }

--- a/web-app/src/app/_services/motor.service.ts
+++ b/web-app/src/app/_services/motor.service.ts
@@ -3,6 +3,7 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { ITelemetryData } from '../_objects/interfaces/telemetry-data.interface';
 import { Motor } from '../_objects/motor';
 import { WebSocketService } from '../websocket.service';
+import { RoundingService } from './rounding.service';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +16,7 @@ export class MotorService {
   private motor0: Motor;
   private motor1: Motor;
 
-  constructor(private wsService: WebSocketService) {
+  constructor(private wsService: WebSocketService, private rService: RoundingService) {
     this.motor0$ = new EventEmitter<Motor>();
     this.motor1$ = new EventEmitter<Motor>();
 
@@ -39,26 +40,26 @@ export class MotorService {
 
   private updateMotor(data: ITelemetryData, num: number): void {
     this[`motor${num}`].alive = data[`motor${num}alive`];
-    this[`motor${num}`].backEmf = data[`motor${num}backemf`];
-    this[`motor${num}`].busCurrent = data[`motor${num}buscurrent`];
-    this[`motor${num}`].busVoltage = data[`motor${num}busvoltage`];
-    this[`motor${num}`].dcBusAmpHours = data[`motor${num}dcbusamphours`];
-    this[`motor${num}`].dspBoardTemp = data[`motor${num}dspboardtemp`];
-    this[`motor${num}`].heatSinkTemp = data[`motor${num}heatsinktemp`];
-    this[`motor${num}`].motorCurrentImaginary = data[`motor${num}motorcurrentimaginary`];
-    this[`motor${num}`].motorCurrentReal = data[`motor${num}motorcurrentreal`];
-    this[`motor${num}`].motorTemp = data[`motor${num}motortemp`];
-    this[`motor${num}`].motorVoltageImaginary = data[`motor${num}motorvoltageimaginary`];
-    this[`motor${num}`].motorVoltageReal = data[`motor${num}motorvoltagereal`];
-    this[`motor${num}`].odometer = data[`motor${num}odometer`];
-    this[`motor${num}`].phaseBCurrent = data[`motor${num}phasebcurrent`];
-    this[`motor${num}`].phaseCCurrent = data[`motor${num}phaseccurrent`];
-    this[`motor${num}`].setCurrent = data[`motor${num}setcurrent`];
-    this[`motor${num}`].setVelocity = data[`motor${num}setvelocity`];
-    this[`motor${num}`].slipSpeed = data[`motor${num}slipspeed`];
-    this[`motor${num}`].vehicleVelocity = data[`motor${num}vehiclevelocity`];
-    this[`motor${num}`].voltageRail15VSupply = data[`motor${num}voltagerail15vsupply`];
-    this[`motor${num}`].voltageRail1VSupply = data[`motor${num}voltagerail1vsupply`];
-    this[`motor${num}`].voltageRail3VSupply = data[`motor${num}voltagerail3vsupply`];
+    this[`motor${num}`].backEmf = this.rService.getRoundedValue(data[`motor${num}backemf`], 2);
+    this[`motor${num}`].busCurrent = this.rService.getRoundedValue(data[`motor${num}buscurrent`], 2);
+    this[`motor${num}`].busVoltage = this.rService.getRoundedValue(data[`motor${num}busvoltage`], 2);
+    this[`motor${num}`].dcBusAmpHours = this.rService.getRoundedValue(data[`motor${num}dcbusamphours`], 2);
+    this[`motor${num}`].dspBoardTemp = this.rService.getRoundedValue(data[`motor${num}dspboardtemp`], 2);
+    this[`motor${num}`].heatSinkTemp = this.rService.getRoundedValue(data[`motor${num}heatsinktemp`], 2);
+    this[`motor${num}`].motorCurrentImaginary = this.rService.getRoundedValue(data[`motor${num}motorcurrentimaginary`], 2);
+    this[`motor${num}`].motorCurrentReal = this.rService.getRoundedValue(data[`motor${num}motorcurrentreal`], 2);
+    this[`motor${num}`].motorTemp = this.rService.getRoundedValue(data[`motor${num}motortemp`], 2);
+    this[`motor${num}`].motorVoltageImaginary = this.rService.getRoundedValue(data[`motor${num}motorvoltageimaginary`], 2);
+    this[`motor${num}`].motorVoltageReal = this.rService.getRoundedValue(data[`motor${num}motorvoltagereal`], 2);
+    this[`motor${num}`].odometer = this.rService.getRoundedValue(data[`motor${num}odometer`], 2);
+    this[`motor${num}`].phaseBCurrent = this.rService.getRoundedValue(data[`motor${num}phasebcurrent`], 2);
+    this[`motor${num}`].phaseCCurrent = this.rService.getRoundedValue(data[`motor${num}phaseccurrent`], 2);
+    this[`motor${num}`].setCurrent = this.rService.getRoundedValue(data[`motor${num}setcurrent`], 2);
+    this[`motor${num}`].setVelocity = this.rService.getRoundedValue(data[`motor${num}setvelocity`], 2);
+    this[`motor${num}`].slipSpeed = this.rService.getRoundedValue(data[`motor${num}slipspeed`], 2);
+    this[`motor${num}`].vehicleVelocity = this.rService.getRoundedValue(data[`motor${num}vehiclevelocity`], 2);
+    this[`motor${num}`].voltageRail15VSupply = this.rService.getRoundedValue(data[`motor${num}voltagerail15vsupply`], 2);
+    this[`motor${num}`].voltageRail1VSupply = this.rService.getRoundedValue(data[`motor${num}voltagerail1vsupply`], 2);
+    this[`motor${num}`].voltageRail3VSupply = this.rService.getRoundedValue(data[`motor${num}voltagerail3vsupply`], 2);
   }
 }

--- a/web-app/src/app/_services/rounding.service.spec.ts
+++ b/web-app/src/app/_services/rounding.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RoundingService } from './rounding.service';
+
+describe('RoundingService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RoundingService]
+    });
+  });
+
+  it('should be created', inject([RoundingService], (service: RoundingService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/web-app/src/app/_services/rounding.service.ts
+++ b/web-app/src/app/_services/rounding.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RoundingService {
+
+  constructor() { }
+
+  getRoundedValue(value: number, precision: number) {
+    return Number(value.toFixed(precision));
+  }
+}


### PR DESCRIPTION
When sending a value such as "66.66" on the test tool, floating values
will be imprecise (eg 66.6600090912), so the site will display long decimals.

Added a rounding service to round each value to 2 decimals. If it doesn't need
to be 2 decimals, it can be changed later.

Fixes #54 