### PR TITLE
Create data service initializer service

### DIFF
--- a/web-app/src/app/_services/data.init.service.spec.ts
+++ b/web-app/src/app/_services/data.init.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { Data.InitService } from './data.init.service';
+
+describe('Data.InitService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [Data.InitService]
+    });
+  });
+
+  it('should be created', inject([Data.InitService], (service: Data.InitService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/web-app/src/app/_services/data.init.service.ts
+++ b/web-app/src/app/_services/data.init.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+
+import { FaultsService } from './faults.service';
+import { AuxBmsService } from './aux-bms.service';
+import { BatteryService } from './battery.service';
+import { ControlsService } from './controls.service';
+import { LightsService } from './lights.service';
+import { MotorService } from './motor.service';
+import { MpptService } from './mppt.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DataInitService {
+
+  constructor(private fs: FaultsService,
+              private abs: AuxBmsService,
+              private bs: BatteryService,
+              private cs: ControlsService,
+              private ls: LightsService,
+              private mots: MotorService,
+              private mps: MpptService,
+              ) {console.log("Initializing Data Services") }
+
+  load() {
+    return new Promise((resolve, reject) => {
+      resolve(true)
+    })
+  }
+}
+
+export function DataProviderFactory(provider: DataInitService) {
+  return provider.load();
+}

--- a/web-app/src/app/_services/data.init.service.ts
+++ b/web-app/src/app/_services/data.init.service.ts
@@ -20,7 +20,7 @@ export class DataInitService {
               private ls: LightsService,
               private mots: MotorService,
               private mps: MpptService,
-              ) {console.log("Initializing Data Services") }
+              ) {}
 
   load() {
     return new Promise((resolve, reject) => {

--- a/web-app/src/app/app.module.ts
+++ b/web-app/src/app/app.module.ts
@@ -23,6 +23,8 @@ import { MpptComponent } from './tabs/mppt/mppt.component';
 import { RightpanelComponent } from './rightpanel/rightpanel.component';
 
 import { WebSocketService } from './websocket.service';
+import { DataInitService } from './_services/data.init.service';
+import { APP_INITIALIZER } from '@angular/core';
 
 @NgModule({
   declarations: [
@@ -52,7 +54,14 @@ import { WebSocketService } from './websocket.service';
     MatProgressSpinnerModule,
     MatTabsModule
   ],
-  providers: [WebSocketService],
+  providers: [
+    WebSocketService,
+    DataInitService,
+    { provide: APP_INITIALIZER,
+      useFactory: (fs: DataInitService) => function() {return fs.load()},
+      deps: [DataInitService],
+      multi: true },
+  ],
   bootstrap: [AppComponent]
 })
 


### PR DESCRIPTION
The data services were not being initialized on startup.
They were initialized when the component using them was constructed.
This was causing issues as the faults page was not being created by the side
panels, like the other ones. The result was that if you loaded the program
on any other page (eg. MPPT), switching to the faults page would not display
any new data.

We need to implement a initializer class, and add that as a provider
with APP_INITIALIZER to run on startup.

References:
https://stackoverflow.com/a/44731279
https://devblog.dymel.pl/2017/10/17/angular-preload/

Fixes #61 