### PR TITLE
Implement a websocket multplexer

### DIFF
--- a/server/scripts/amqp.js
+++ b/server/scripts/amqp.js
@@ -31,6 +31,7 @@ amqp.connect(config.rabbitmq.host)
           db.insert('rabbitmq-insert', jsonObj)
             .then((insertedRow) => {
               console.log('1 row inserted from RabbitMQ');
+              insertedRow['msgType'] = 'packet';
               // send to angular clients
               wss.broadcast(JSON.stringify(insertedRow));
             });

--- a/server/scripts/database.js
+++ b/server/scripts/database.js
@@ -77,7 +77,7 @@ module.exports.insert = function(queryName, jsonObj) {
  * Fetches the last row in the database.
  * @return {Promise}
  */
-module.exports.last = function() {
+module.exports.lastPacket = function() {
   return db.one({
     name: 'client-init',
     text: 'SELECT * ' +
@@ -86,6 +86,18 @@ module.exports.last = function() {
   });
 };
 
+/**
+* Fetches all the laps in the database
+* @return {Promise}
+*/
+module.exports.laps = function() {
+  return db.any({
+    name: 'client-init-lap',
+    text: 'SELECT * ' +
+          'FROM lap ' +
+          'ORDER BY timestamp DESC',
+  });
+};
 /**
  * Function that maps the JSON object fields from the DigitalOcean RabbitMQ
  * to the PostgreSQL database columns.

--- a/server/scripts/websocket.js
+++ b/server/scripts/websocket.js
@@ -11,7 +11,7 @@ const errors = {
 wss.on('connection', function(ws, req) {
   // when client connects, fetch last row in db
   console.log('New client connected!');
-  db.last()
+  db.lastPacket()
     // send to client
     .then((lastRow) => {
       // make the datetime pretty
@@ -22,6 +22,14 @@ wss.on('connection', function(ws, req) {
     .catch((err) => {
       ws.send({error: errors.SELECT_ERROR});
     });
+  db.laps()
+  .then((laps) => {
+    // console.log(laps)
+    for (let lap = 0; lap < laps.length; lap++) {
+      laps[lap]['msgType'] = 'lap';
+      ws.send(JSON.stringify(laps[lap]));
+    }
+  });
 });
 
 wss.broadcast = function broadcast(data) {

--- a/server/scripts/websocket.js
+++ b/server/scripts/websocket.js
@@ -15,6 +15,7 @@ wss.on('connection', function(ws, req) {
     // send to client
     .then((lastRow) => {
       // make the datetime pretty
+      lastRow['msgType'] = 'packet';
       ws.send(JSON.stringify(lastRow));
     })
     // send error if cannot fetch last row

--- a/web-app/src/app/_services/aux-bms.service.ts
+++ b/web-app/src/app/_services/aux-bms.service.ts
@@ -17,7 +17,7 @@ export class AuxBmsService {
     this.auxbms$ = new EventEmitter<AuxBms>();
     this.auxbms = new AuxBms;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateAuxBms(data);
         this.auxbms$.emit(this.getData());

--- a/web-app/src/app/_services/battery.service.ts
+++ b/web-app/src/app/_services/battery.service.ts
@@ -18,7 +18,7 @@ export class BatteryService {
     this.battery$ = new EventEmitter<Battery>();
     this.battery = new Battery;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateBattery(data);
         this.battery$.emit(this.getData());

--- a/web-app/src/app/_services/controls.service.ts
+++ b/web-app/src/app/_services/controls.service.ts
@@ -17,7 +17,7 @@ export class ControlsService {
     this.controls$ = new EventEmitter<Controls>();
     this.controls = new Controls;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateControls(data);
         this.controls$.emit(this.getData());

--- a/web-app/src/app/_services/faults.service.ts
+++ b/web-app/src/app/_services/faults.service.ts
@@ -27,7 +27,7 @@ export class FaultsService {
     this.motor0Faults = new MotorFaults;
     this.motor1Faults = new MotorFaults;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateBatteryFaults(data);
         this.updateMotorFaults(data, 0);

--- a/web-app/src/app/_services/lights.service.ts
+++ b/web-app/src/app/_services/lights.service.ts
@@ -17,7 +17,7 @@ export class LightsService {
     this.lights$ = new EventEmitter<Lights>();
     this.lights = new Lights;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateLights(data);
         this.lights$.emit(this.getData());

--- a/web-app/src/app/_services/motor.service.ts
+++ b/web-app/src/app/_services/motor.service.ts
@@ -23,7 +23,7 @@ export class MotorService {
     this.motor0 = new Motor;
     this.motor1 = new Motor;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateMotor(data, 0);
         this.updateMotor(data, 1);

--- a/web-app/src/app/_services/mppt.service.ts
+++ b/web-app/src/app/_services/mppt.service.ts
@@ -30,7 +30,7 @@ export class MpptService {
     this.mppt2 = new Mppt;
     this.mppt3 = new Mppt;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.updateMppt(data, 0);
         this.updateMppt(data, 1);

--- a/web-app/src/app/_services/packet.service.ts
+++ b/web-app/src/app/_services/packet.service.ts
@@ -17,7 +17,7 @@ export class PacketService {
     this.packet$ = new EventEmitter<Packet>();
     this.packet = new Packet;
 
-    this.wsService.socket$.subscribe(
+    this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
         this.packet$.emit(this.getData());
         this.packet.name = data.name;

--- a/web-app/src/app/websocket.service.ts
+++ b/web-app/src/app/websocket.service.ts
@@ -12,6 +12,7 @@ export class WebSocketService {
   socket$: WebSocketSubject<any>;
 
   packetMultiplex$: Observable<any>;
+  lapMultiplex$: Observable<any>;
 
   constructor() {
     this.socket$ = webSocket('ws://localhost:4000');
@@ -19,6 +20,11 @@ export class WebSocketService {
          () => ({subscribe: ''}),
          () => ({unsubscribe: ''}),
          message => (message.msgType === 'packet') // Messages will go through if this passes
+        )
+    this.lapMultiplex$ = this.socket$.multiplex(
+         () => ({subscribe: ''}),
+         () => ({unsubscribe: ''}),
+         message => (message.msgType === 'lap')
         )
   }
 }

--- a/web-app/src/app/websocket.service.ts
+++ b/web-app/src/app/websocket.service.ts
@@ -2,15 +2,23 @@ import { Injectable } from '@angular/core';
 
 import { ITelemetryData } from './_objects/interfaces/telemetry-data.interface';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class WebSocketService {
 
-  socket$: WebSocketSubject<ITelemetryData>;
+  socket$: WebSocketSubject<any>;
+
+  packetMultiplex$: Observable<any>;
 
   constructor() {
     this.socket$ = webSocket('ws://localhost:4000');
+    this.packetMultiplex$ = this.socket$.multiplex(
+         () => ({subscribe: ''}),
+         () => ({unsubscribe: ''}),
+         message => (message.msgType === 'packet') // Messages will go through if this passes
+        )
   }
 }


### PR DESCRIPTION
A multiplexer basically allows us to filter out messages from a websocket, in this case by checking a msgtype field. This is how we'll differentiate between lap packets and web packets sent by the server.

Things should still actually work the same once you reset your database. 
```
sudo -u postgres dropdb epsilontelemetrydb
sudo -u postgres createdb epsilontelemetrydb
sudo -u postgres psql epsilontelemetrydb < migrate.psql
``` 

https://rxjs-dev.firebaseapp.com/guide/observable