### PR TITLE
Convert timestamps to unix timestamps

### DIFF
--- a/server/migrate.psql
+++ b/server/migrate.psql
@@ -40,7 +40,7 @@ SET default_with_oids = false;
 
 CREATE TABLE public.lap (
     lapnumber bigint NOT NULL,
-    "timestamp" timestamp without time zone NOT NULL,
+    "timestamp" bigint NOT NULL,
     secondsdifference integer,
     totalpowerin double precision,
     totalpowerout double precision,
@@ -81,7 +81,7 @@ ALTER SEQUENCE public.lap_lapnumber_seq OWNED BY public.lap.lapnumber;
 
 CREATE TABLE public.packet (
     id bigint NOT NULL,
-    "timestamp" timestamp without time zone NOT NULL,
+    "timestamp" bigint NOT NULL,
     name text NOT NULL,
     motor0alive boolean,
     motor0setcurrent double precision,

--- a/server/scripts/database.js
+++ b/server/scripts/database.js
@@ -129,9 +129,6 @@ module.exports.lastLap = function() {
   });
 };
 
-// Time
-const moment = require('moment');
-
 /**
 * Function that inserts a new lap entry to the lap table
 **/
@@ -151,7 +148,7 @@ module.exports.addLap = function() {
     'batterysecondsremaining',
   ];
 
-  const tokens = [0, moment().format('YYYY-MM-DD HH:mm:ss.SSS'), 100, 100, 100, 100, 100, 100, 100, 100];
+  const tokens = [0, 0, 100, 100, 100, 100, 100, 100, 100, 100];
   return db.one({
     name: `insertLap`,
     text: `INSERT INTO lap (${columns}) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *`,
@@ -168,8 +165,9 @@ module.exports.addLap = function() {
  */
 function jsonToMap(jsonObj) {
   const mapObj = Object.assign(columnMap);
+  const timestamp = (new Date(jsonObj['TimeStamp']).getTime()).toFixed(0);
   mapObj.set('timestamp',
-    `${jsonObj['TimeStamp']}`);
+    `${timestamp}`);
   mapObj.set('name',
     `${jsonObj['PacketTitle']}`);
   mapObj.set('motor0alive',

--- a/server/scripts/websocket.js
+++ b/server/scripts/websocket.js
@@ -24,7 +24,6 @@ wss.on('connection', function(ws, req) {
     });
   db.laps()
   .then((laps) => {
-    // console.log(laps)
     for (let lap = laps.length - 1; lap >= 0; --lap) {
       laps[lap]['msgType'] = 'lap';
       ws.send(JSON.stringify(laps[lap]));

--- a/web-app/src/app/_objects/interfaces/lap-data.interface.ts
+++ b/web-app/src/app/_objects/interfaces/lap-data.interface.ts
@@ -1,6 +1,6 @@
 export interface ILapDataInterface {
     lapnumber: number,
-    timestamp: string,
+    secondsdifference: number,
     totalpowerin: number,
     totalpowerout: number,
     netpowerout: number,

--- a/web-app/src/app/_objects/interfaces/telemetry-data.interface.ts
+++ b/web-app/src/app/_objects/interfaces/telemetry-data.interface.ts
@@ -1,6 +1,6 @@
 export interface ITelemetryData {
   id: number,
-  timestamp: string,
+  timestamp: number,
   name: string,
   motor0alive: boolean,
   motor0setcurrent: number,

--- a/web-app/src/app/_objects/packet.ts
+++ b/web-app/src/app/_objects/packet.ts
@@ -1,4 +1,8 @@
 export class Packet {
-  name = 'NO DATA';
-  timestamp = null; // format: yyyy-MM-dd-hh-mm-ss-zzz
+  timestamp: number;
+  name: string;
+  constructor() {
+    this.name = 'NO DATA';
+    this.timestamp = 0;
+  }
 }

--- a/web-app/src/app/_services/heartbeat.service.ts
+++ b/web-app/src/app/_services/heartbeat.service.ts
@@ -27,9 +27,8 @@ export class HeartbeatService {
   }
 
    heartBeatCheck() {
-    const packetTime = Date.parse(this.packet.timestamp);
-
-    if (Number.isNaN(packetTime) || Date.now() - packetTime > this.interval) {
+    const packetTime = new Date(this.packet.timestamp);
+    if (Date.now() - this.packet.timestamp > this.interval) {
         this.heartBeat$.emit(false);
     } else {
         this.heartBeat$.emit(true);

--- a/web-app/src/app/_services/lap.service.ts
+++ b/web-app/src/app/_services/lap.service.ts
@@ -29,7 +29,7 @@ export class LapService {
   updateLapData(data: ILapDataInterface): void {
     const newData = new LapData();
     newData.lapNumber = data.lapnumber;
-    newData.lapTime = data.timestamp;
+    newData.lapTime = '22:22:00';
     newData.totalPowerIn = data.totalpowerin;
     newData.totalPowerOut = data.totalpowerout;
     newData.netPowerOut = data.netpowerout;

--- a/web-app/src/app/_services/lap.service.ts
+++ b/web-app/src/app/_services/lap.service.ts
@@ -29,7 +29,9 @@ export class LapService {
   updateLapData(data: ILapDataInterface): void {
     const newData = new LapData();
     newData.lapNumber = data.lapnumber;
-    newData.lapTime = '22:22:00';
+
+    newData.lapTime = this.getTimeString(data.secondsdifference);
+
     newData.totalPowerIn = data.totalpowerin;
     newData.totalPowerOut = data.totalpowerout;
     newData.netPowerOut = data.netpowerout;
@@ -39,5 +41,13 @@ export class LapService {
     newData.batterySecondsRemaining = data.batterysecondsremaining;
 
     this.lapDataArray.unshift(newData)
+  }
+
+  getTimeString(secondsdifference): string {
+
+    // Display seconds difference as "HH:MM:SS"
+    const date = new Date(null);
+    date.setMilliseconds(secondsdifference);
+    return date.toISOString().substr(11, 8);
   }
 }

--- a/web-app/src/app/_services/packet.service.ts
+++ b/web-app/src/app/_services/packet.service.ts
@@ -19,9 +19,9 @@ export class PacketService {
 
     this.wsService.packetMultiplex$.subscribe(
       (data: ITelemetryData) => {
-        this.packet$.emit(this.getData());
         this.packet.name = data.name;
-        this.packet.timestamp = new Date(data.timestamp);
+        this.packet.timestamp = data.timestamp;
+        this.packet$.emit(this.getData());
       }
     );
   }

--- a/web-app/src/app/leftpanel/leftpanel.component.html
+++ b/web-app/src/app/leftpanel/leftpanel.component.html
@@ -8,7 +8,7 @@
   <mat-form-field>
     <input matInput
       placeholder="Packet Timestamp"
-      value="{{packet.timestamp | date: 'MMM d, y, h:mm:ss a'}}"
+      value="{{timestamp | date: 'MMM d, y, h:mm:ss a'}}"
       readonly="true"
     >
   </mat-form-field>

--- a/web-app/src/app/leftpanel/leftpanel.component.ts
+++ b/web-app/src/app/leftpanel/leftpanel.component.ts
@@ -14,6 +14,7 @@ export class LeftpanelComponent implements OnInit {
   packet: Packet;
 
   heartBeat: Boolean;
+  timestamp: Date;
   // inject the PacketService
   constructor(private packetService: PacketService, private heartbeatService: HeartbeatService) {
   }
@@ -21,7 +22,7 @@ export class LeftpanelComponent implements OnInit {
   ngOnInit() {
     // initialize with default values
     this.packet = this.packetService.getData();
-
+    this.timestamp = new Date(Number(this.packet.timestamp))
     // observe changes and update public variable when changed
     // note the dollar sign, this means you can subscribe to the object
     // see _services/packet.service.ts
@@ -29,6 +30,7 @@ export class LeftpanelComponent implements OnInit {
       (data: Packet) => {
         this.packet = data;
         this.heartBeat = true;
+        this.timestamp  = new Date(Number(this.packet.timestamp))
       }
     );
     this.heartbeatService.heartBeat$.subscribe(


### PR DESCRIPTION
Fixes #131 

Unix timestamps are more reliable than the timestamp type in postgres, and is easier to do computations with.