### PR TITLE
SFT-173 Add websocket address to environment.ts variables

### DIFF
--- a/web-app/src/app/websocket.service.ts
+++ b/web-app/src/app/websocket.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { ITelemetryData } from './_objects/interfaces/telemetry-data.interface';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +16,7 @@ export class WebSocketService {
   lapMultiplex$: Observable<any>;
 
   constructor() {
-    this.socket$ = webSocket('ws://localhost:4000');
+    this.socket$ = webSocket(environment.serverIP);
     this.packetMultiplex$ = this.socket$.multiplex(
          () => ({subscribe: ''}),
          () => ({unsubscribe: ''}),

--- a/web-app/src/environments/environment.prod.ts
+++ b/web-app/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  serverIP: 'ws://138.197.206.227:4000'
 };

--- a/web-app/src/environments/environment.ts
+++ b/web-app/src/environments/environment.ts
@@ -4,5 +4,6 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  serverIP: 'ws://localhost:4000'
 };


### PR DESCRIPTION
Allows you to call ng builds --prod without having to open websocket.service
https://angular.io/guide/build - More info

To test:
1. `ng serve` should connect the site to your local database
2. `ng serve --prod` should connect the site to the database on telemetry.calgarysolarcar.ca